### PR TITLE
feat(TPSVC-19099): enable removing users with group patch for OneLogin

### DIFF
--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
@@ -45,6 +45,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * An individual patch operation.
@@ -216,16 +218,32 @@ public abstract class PatchOperation
      * @param path The path targeted by this patch operation.
      * @throws ScimException If a path is null.
      */
-    @JsonCreator
     private RemoveOperation(
-        @JsonProperty(value = "path", required = true) final Path path)
-        throws ScimException
+            @JsonProperty(value = "path", required = true) final Path path)
+            throws ScimException
     {
       super(path);
       if(path == null)
       {
         throw BadRequestException.noTarget(
+                "path field must not be null for remove operations");
+      }
+    }
+
+    @JsonCreator
+    private RemoveOperation(@JsonProperty(value = "path", required = true) Path path,
+                            @JsonProperty(value = "value") final JsonNode value) throws ScimException {
+      super(path);
+      if(path == null) {
+        throw BadRequestException.noTarget(
             "path field must not be null for remove operations");
+      }
+
+      if (null != value && "members".equalsIgnoreCase(path.toString())) {
+        path = Path.fromString(StreamSupport.stream(value.spliterator(), false)
+                .map(memberNode -> memberNode.get("value").textValue())
+                .collect(Collectors.joining("\" or value eq \"", "members[value eq \"", "\"]")));
+        this.setPath(path);
       }
     }
 
@@ -418,7 +436,7 @@ public abstract class PatchOperation
     }
   }
 
-  private final Path path;
+  private Path path;
 
   /**
    * Create a new patch operation.
@@ -428,6 +446,10 @@ public abstract class PatchOperation
    */
   PatchOperation(final Path path) throws ScimException
   {
+    this.setPath(path);
+  }
+
+  protected void setPath(Path path) throws ScimException {
     if(path != null)
     {
       if(path.size() > 2)
@@ -1325,6 +1347,18 @@ public abstract class PatchOperation
     }
     catch (ScimException e)
     {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public static PatchOperation remove(final String path, final JsonNode value) throws ScimException {
+    return remove(Path.fromString(path), value);
+  }
+
+  public static PatchOperation remove(final Path path, final JsonNode value) {
+    try {
+      return new RemoveOperation(path, value);
+    } catch (ScimException e) {
       throw new IllegalArgumentException(e);
     }
   }

--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
@@ -213,7 +213,7 @@ public abstract class PatchOperation
   static final class RemoveOperation extends PatchOperation
   {
 
-    public static final String GROUP_MEMBERS_PATH = "members";
+    private static final String GROUP_MEMBERS_PATH = "members";
 
     /**
      * Create a new remove patch operation.

--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
@@ -212,6 +212,9 @@ public abstract class PatchOperation
 
   static final class RemoveOperation extends PatchOperation
   {
+
+    public static final String GROUP_MEMBERS_PATH = "members";
+
     /**
      * Create a new remove patch operation.
      *
@@ -239,10 +242,10 @@ public abstract class PatchOperation
             "path field must not be null for remove operations");
       }
 
-      if (null != value && "members".equalsIgnoreCase(path.toString())) {
+      if (null != value && GROUP_MEMBERS_PATH.equalsIgnoreCase(path.toString())) {
         path = Path.fromString(StreamSupport.stream(value.spliterator(), false)
                 .map(memberNode -> memberNode.get("value").textValue())
-                .collect(Collectors.joining("\" or value eq \"", "members[value eq \"", "\"]")));
+                .collect(Collectors.joining("\" or value eq \"", GROUP_MEMBERS_PATH + "[value eq \"", "\"]")));
         this.setPath(path);
       }
     }

--- a/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
@@ -346,6 +346,70 @@ public class PatchOpTestCase
 
   }
 
+  @Test
+  public void getTestPatchRemoveGroupMemberWithValue() throws IOException, ScimException {
+    PatchRequest patchOp = JsonUtils.getObjectReader().
+        forType(PatchRequest.class).
+        readValue("{" +
+                  "    \"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"]," +
+                  "    \"Operations\":[{" +
+                  "       \"value\":[{\"value\":\"user-id-remove\"}]," +
+                  "       \"op\":\"remove\"," +
+                  "       \"path\":\"members\"" +
+                  "    }]" +
+                  "}");
+
+    JsonNode prePatchResource = JsonUtils.getObjectReader().
+        readTree("{" +
+                 "  \"schemas\" : [ \"urn:ietf:params:scim:schemas:core:2.0:Group\" ]," +
+                 "  \"id\" : \"group-id\"," +
+                 "  \"meta\" : {" +
+                 "    \"lastModified\" : \"2022-08-03T13:55:27.761Z\"," +
+                 "    \"resourceType\" : \"Group\"," +
+                 "    \"location\" : \"https://api.int.cloud.talend.com/scim/v2/Groups/group-id\"" +
+                 "  }," +
+                 "  \"displayName\" : \"Group Name\"," +
+                 "  \"members\" : [{" +
+                 "      \"value\" : \"user-id\"," +
+                 "      \"display\" : \"User Name\"," +
+                 "      \"$ref\" : \"https://api.int.cloud.talend.com/scim/v2/Users/user-id\"" +
+                 "    },{" +
+                 "      \"value\" : \"user-id-remove\"," +
+                 "      \"display\" : \"User Remove\"," +
+                 "      \"$ref\" : \"https://api.int.cloud.talend.com/scim/v2/Users/user-id-remove\"" +
+                 "  }]" +
+                 "}");
+
+    JsonNode postPatchResource = JsonUtils.getObjectReader().
+        readTree("{" +
+                 "  \"schemas\" : [ \"urn:ietf:params:scim:schemas:core:2.0:Group\" ]," +
+                 "  \"id\" : \"group-id\"," +
+                 "  \"meta\" : {" +
+                 "    \"lastModified\" : \"2022-08-03T13:55:27.761Z\"," +
+                 "    \"resourceType\" : \"Group\"," +
+                 "    \"location\" : \"https://api.int.cloud.talend.com/scim/v2/Groups/group-id\"" +
+                 "  }," +
+                 "  \"displayName\" : \"Group Name\"," +
+                 "  \"members\" : [{" +
+                 "    \"value\" : \"user-id\"," +
+                 "    \"display\" : \"User Name\"," +
+                 "    \"$ref\" : \"https://api.int.cloud.talend.com/scim/v2/Users/user-id\"" +
+                 "  }]" +
+                 "}");
+
+    GenericScimResource scimResource = new GenericScimResource((ObjectNode) prePatchResource);
+    patchOp.apply(scimResource);
+    assertEquals(scimResource.getObjectNode(), postPatchResource);
+
+    PatchRequest constructed = new PatchRequest(patchOp.getOperations());
+
+    assertEquals(constructed, patchOp);
+
+    String serialized = JsonUtils.getObjectWriter().writeValueAsString(constructed);
+    assertEquals(JsonUtils.getObjectReader().forType(PatchRequest.class).readValue(serialized), constructed);
+
+  }
+
   /**
    * Test bad patch requests.
    *


### PR DESCRIPTION
[TPSVC-19099](https://jira.talendforge.org/browse/TPSVC-19099): _Implement SCIM 2.0 PATCH request for Group endpoint_

OneLogin sends payload containing `value` field to remove user from group, which is not supported by default:
```
{
  "schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
  "Operations":[{
    "value":[{"value":"4391a935-87c9-42b9-830c-4c576ea0dd9a"}],
    "op":"remove",
    "path":"members"
  }]
}
```
[This issue](https://github.com/Captain-P-Goldfish/SCIM-SDK/issues/149) was open because Azure follows same pattern
