### PR TITLE
fix(TPSVC-19180): Accept filter in patch path for add op

### DIFF
--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/messages/PatchOperation.java
@@ -94,18 +94,6 @@ public abstract class PatchOperation
             "value field must be a JSON object containing the attributes to " +
                 "add");
       }
-      if(path != null)
-      {
-        for (Path.Element element : path)
-        {
-          if(element.getValueFilter() != null)
-          {
-            throw BadRequestException.invalidPath(
-                "path field for add operations must not include any value " +
-                    "selection filters");
-          }
-        }
-      }
       this.value = value;
     }
 

--- a/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
@@ -61,6 +61,11 @@ public class PatchOpTestCase
             "  \"Operations\":[  \n" +
             "    {  \n" +
             "      \"op\":\"add\",\n" +
+            "      \"path\":\"addresses[type eq \\\"home\\\"].postalCode\",\n" +
+            "      \"value\":\"91608\"\n" +
+            "    }," +
+            "    {  \n" +
+            "      \"op\":\"add\",\n" +
             "      \"value\":{  \n" +
             "        \"emails\":[  \n" +
             "          {  \n" +
@@ -230,7 +235,6 @@ public class PatchOpTestCase
             "      \"streetAddress\":\"456 Hollywood Blvd\",\n" +
             "      \"locality\":\"Hollywood\",\n" +
             "      \"region\":\"CA\",\n" +
-            "      \"postalCode\":\"91608\",\n" +
             "      \"country\":\"USA\",\n" +
             "      \"formatted\":\"456 Hollywood Blvd\\nHollywood, " +
             "CA 91608 USA\"\n" +
@@ -411,17 +415,40 @@ public class PatchOpTestCase
   }
 
   @Test
-  public void getTestPatchWithLowercaseOperations() throws IOException, ScimException {
+  public void getTestPatchAddWithPathFilter() throws IOException {
     PatchRequest patchOp = JsonUtils.getObjectReader().
         forType(PatchRequest.class).
         readValue("{" +
                   "    \"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"]," +
                   "    \"operations\":[{" +
-                  "       \"value\":[{\"value\":\"user-id-remove\"}]," +
-                  "       \"op\":\"remove\"," +
-                  "       \"path\":\"members\"" +
+                  "       \"value\":\"44200\"," +
+                  "       \"op\":\"add\"," +
+                  "       \"path\":\"addresses[type eq \\\"work\\\"].postalCode\"" +
                   "    }]" +
                   "}");
+
+    PatchRequest constructed = new PatchRequest(patchOp.getOperations());
+    String serialized = JsonUtils.getObjectWriter().writeValueAsString(constructed);
+
+    assertEquals(constructed, patchOp);
+    assertEquals(patchOp.getOperations().size(), 1);
+    assertEquals(patchOp.getOperations().iterator().next().getOpType(), PatchOpType.ADD);
+    assertEquals(JsonUtils.getObjectReader().forType(PatchRequest.class).readValue(serialized), constructed);
+
+  }
+
+  @Test
+  public void getTestPatchWithLowercaseOperations() throws IOException, ScimException {
+    PatchRequest patchOp = JsonUtils.getObjectReader().
+            forType(PatchRequest.class).
+            readValue("{" +
+                    "    \"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"]," +
+                    "    \"operations\":[{" +
+                    "       \"value\":[{\"value\":\"user-id-remove\"}]," +
+                    "       \"op\":\"remove\"," +
+                    "       \"path\":\"members\"" +
+                    "    }]" +
+                    "}");
 
     PatchRequest constructed = new PatchRequest(patchOp.getOperations());
     String serialized = JsonUtils.getObjectWriter().writeValueAsString(constructed);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Filters are not accepted in path for add patch operation.

See https://jira.talendforge.org/browse/TPSVC-19180

ℹ️ This anomaly [has already been reported](https://github.com/pingidentity/scim2/commit/4b3d63c7c22ec044f5da4bb14848ac1366a3fa13) in the source library.

**What is the chosen solution to this problem?**
Accept filter for path even for add op.

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
