### PR TITLE
TPSVC-19180: Patch operations - create missing objects

### DIFF
--- a/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/utils/JsonUtils.java
+++ b/scim2-sdk-common/src/main/java/com/bettercloud/scim2/common/utils/JsonUtils.java
@@ -17,6 +17,7 @@
 
 package com.bettercloud.scim2.common.utils;
 
+import com.bettercloud.scim2.common.filters.FilterType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -242,6 +243,14 @@ public class JsonUtils
               filterArray((ArrayNode)node, valueFilter, false);
           if(arrayNode.size() == 0)
           {
+            // Create missing object only in case of simple filter (eq filter with simple path).
+            // Example: addresses[type eq "home"] will create {"type":"home"} in addresses array.
+            if (valueFilter.getFilterType() == FilterType.EQUAL && valueFilter.getAttributePath().size() == 1) {
+              return ((ArrayNode)node).addObject().set(
+                      valueFilter.getAttributePath().getElement(0).getAttribute(),
+                      valueFilter.getComparisonValue()
+              );
+            }
             throw BadRequestException.noTarget("Attribute " +
                 field + " does not have a value matching the " +
                 "filter " + valueFilter);

--- a/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
+++ b/scim2-sdk-common/src/test/java/com/bettercloud/scim2/common/PatchOpTestCase.java
@@ -351,6 +351,83 @@ public class PatchOpTestCase
   }
 
   @Test
+  public void getTestPatchCreateMissingObject() throws IOException, ScimException
+  {
+    PatchRequest patchOp = JsonUtils.getObjectReader().
+            forType(PatchRequest.class).
+            readValue("{  \n" +
+                    "  \"schemas\":[  \n" +
+                    "    \"urn:ietf:params:scim:api:messages:2.0:PatchOp\"\n" +
+                    "  ],\n" +
+                    "  \"Operations\":[  \n" +
+                    "    {  \n" +
+                    "      \"op\":\"add\",\n" +
+                    "      \"path\":\"addresses[type eq \\\"home\\\"].postalCode\",\n" +
+                    "      \"value\":\"44000\"\n" +
+                    "    }," +
+                    "    {  \n" +
+                    "      \"op\":\"add\",\n" +
+                    "      \"path\":\"addresses[type eq \\\"home\\\"].locality\",\n" +
+                    "      \"value\":\"Nantes\"\n" +
+                    "    }," +
+                    "    {  \n" +
+                    "      \"op\":\"add\",\n" +
+                    "      \"path\":\"phoneNumbers[type eq \\\"mobile\\\"].value\",\n" +
+                    "      \"value\":\"+0000000000\"\n" +
+                    "    }" +
+                    "  ]\n" +
+                    "}");
+
+    JsonNode prePatchResource = JsonUtils.getObjectReader().
+            readTree("{  \n" +
+                    "  \"schemas\":[  \n" +
+                    "    \"urn:ietf:params:scim:schemas:core:2.0:User\"\n" +
+                    "  ],\n" +
+                    "  \"id\":\"2819c223-7f76-453a-919d-413861904646\",\n" +
+                    "  \"userName\":\"bjensen@example.com\",\n" +
+                    "  \"addresses\":[],\n" +
+                    "  \"phoneNumbers\":[]\n" +
+                    "}");
+
+    JsonNode postPatchResource = JsonUtils.getObjectReader().
+            readTree("{  \n" +
+                    "  \"schemas\":[  \n" +
+                    "    \"urn:ietf:params:scim:schemas:core:2.0:User\"\n" +
+                    "  ],\n" +
+                    "  \"id\":\"2819c223-7f76-453a-919d-413861904646\",\n" +
+                    "  \"userName\":\"bjensen@example.com\",\n" +
+                    "  \"addresses\":[  \n" +
+                    "    {  \n" +
+                    "      \"type\":\"home\",\n" +
+                    "      \"postalCode\":\"44000\",\n" +
+                    "      \"locality\":\"Nantes\"\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"phoneNumbers\":[  \n" +
+                    "    {  \n" +
+                    "      \"type\":\"mobile\",\n" +
+                    "      \"value\":\"+0000000000\"\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}");
+
+    GenericScimResource scimResource =
+            new GenericScimResource((ObjectNode)prePatchResource);
+    patchOp.apply(scimResource);
+    assertEquals(scimResource.getObjectNode(), postPatchResource);
+
+    PatchRequest constructed = new PatchRequest(patchOp.getOperations());
+
+    assertEquals(constructed, patchOp);
+
+    String serialized = JsonUtils.getObjectWriter().
+            writeValueAsString(constructed);
+    assertEquals(JsonUtils.getObjectReader().forType(PatchRequest.class).
+            readValue(serialized), constructed);
+
+  }
+
+  @Test
   public void getTestPatchRemoveGroupMemberWithValue() throws IOException, ScimException {
     PatchRequest patchOp = JsonUtils.getObjectReader().
         forType(PatchRequest.class).


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Azure performs the following `PATCH` call when a user is deactivated:
```
{
   "schemas":[
      "urn:ietf:params:scim:api:messages:2.0:PatchOp"
   ],
   "Operations":[
      {
         "op":"Replace",
         "path":"active",
         "value":"False"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].formatted",
         "value":"France-Nantes"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].streetAddress",
         "value":"89 Boulevard de la Prairie au Duc"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].locality",
         "value":"Nantes"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].region",
         "value":"Loire-Atlantique"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].postalCode",
         "value":"44200"
      },
      {
         "op":"Add",
         "path":"phoneNumbers[type eq \"mobile\"].value",
         "value":"-"
      }
   ]
}
```
🔴  Problems : 

- We made the choice to not store any address (because _a SCIM service provider should only accept information it needs_)
- We store only one phone number with the type "work" and don't plan to store other types of phone number (for the same reason as above)

As a result, the whole `PATCH` fails with a `BadRequestException` because the following objects are missing:

- `addresses[type eq "work"]`
- `phoneNumbers[type eq "mobile"]`

**What is the chosen solution to this problem?**
ℹ️ Azure performs the `PATCH` request above because the **work address** and the **mobile phone number** don't exist in the user object, simply because they have not been stored at the creation.

ℹ️ By performing the request above, Azure expects the **work address** and the **mobile phone number** to be created. Hence we shouldn't reply with a bad request error.

💡 The proposed strategy is to create the targeted object if it is missing, based on the informations from the filter. Obviously the filter must match the following criteria:

- The filter must be a simple EQUAL filter
- The filer path must have only one segment

### Example

**Patch operation:**
```
{
   "schemas":[
      "urn:ietf:params:scim:api:messages:2.0:PatchOp"
   ],
   "Operations":[
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].postalCode",
         "value":"44200"
      },
      {
         "op":"Add",
         "path":"addresses[type eq \"work\"].locality",
         "value":"Nantes"
      }
   ]
}

```

**User before patch:**
```
{
   "schemas":[
      "urn:ietf:params:scim:schemas:core:2.0:User"
   ],
   "id":"2819c223-7f76-453a-919d-413861904646",
   "userName":"bjensen@example.com",
   "addresses":[]
}

```

**User after patch:**
```
{
   "schemas":[
      "urn:ietf:params:scim:schemas:core:2.0:User"
   ],
   "id":"2819c223-7f76-453a-919d-413861904646",
   "userName":"bjensen@example.com",
   "addresses":[
        {
           "type":"work",
           "postalCode":"44200",
           "locality":"Nantes"
       }
   ]
}
```

ℹ️ Then the SCIM server will have the choice to handle or not the new object.

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
